### PR TITLE
Comment out gpt-oss:20b model in config

### DIFF
--- a/GPU_Based_LLM/Ollama_OpenWeb_GPU.yml
+++ b/GPU_Based_LLM/Ollama_OpenWeb_GPU.yml
@@ -8,7 +8,7 @@
     app_dir: /opt/local-llm
     ollama_models:
       - mistral:7b
-      - gpt-oss:20b
+      #- gpt-oss:20b
                 
     
     # RSC Catalog variables (these will be provided by SURF Research Cloud)


### PR DESCRIPTION
The gpt-oss:20b model entry in ollama_models is now commented out in Ollama_OpenWeb_GPU.yml, likely to disable its use without removing the configuration.