### PR TITLE
Enhance Open WebUI deployment and config options

### DIFF
--- a/GPU_Based_LLM/Ollama_OpenWeb_GPU.yml
+++ b/GPU_Based_LLM/Ollama_OpenWeb_GPU.yml
@@ -8,7 +8,9 @@
     app_dir: /opt/local-llm
     ollama_models:
       - mistral:7b
-      - gpt-oss:20b
+      #- gpt-oss:20b
+    # Set to true to reset Open WebUI database (fixes auth issues but deletes chat history)
+    reset_openwebui_db: true
                 
     
     # RSC Catalog variables (these will be provided by SURF Research Cloud)
@@ -243,6 +245,9 @@
                 # Set default role to admin to avoid permission issues
                 # Each user authenticated via SRAM will have full access
                 - DEFAULT_USER_ROLE=admin
+                # Disable admin-only access restriction
+                - ENABLE_ADMIN_EXPORT=True
+                - ENABLE_ADMIN_CHAT_ACCESS=False
                 # Enable user isolation - each user gets their own chats
                 - USER_PERMISSIONS_CHAT_DELETION=True
                 - USER_PERMISSIONS_CHAT_EDIT=True
@@ -260,10 +265,25 @@
     # ============================================================
     # Deploy Docker Compose Stack
     # ============================================================
+    - name: Stop existing containers to apply new configuration
+      shell: |
+        cd {{ app_dir }}
+        docker compose down
+      args:
+        chdir: "{{ app_dir }}"
+      failed_when: false
+      changed_when: false
+
+    - name: Remove Open WebUI database volume to reset authentication
+      shell: docker volume rm open-webui-data
+      when: reset_openwebui_db | default(false) | bool
+      failed_when: false
+      changed_when: false
+
     - name: Start Ollama and Open WebUI services with GPU
       shell: |
         cd {{ app_dir }}
-        docker compose up -d
+        docker compose up -d --force-recreate
       args:
         chdir: "{{ app_dir }}"
 
@@ -304,6 +324,24 @@
       retries: 5
       delay: 10
       until: model_check.rc == 0
+
+    - name: Wait for Open WebUI to be ready
+      shell: docker logs open-webui 2>&1 | grep -q "Application startup complete"
+      register: webui_ready
+      until: webui_ready.rc == 0
+      retries: 30
+      delay: 5
+      failed_when: false
+      changed_when: false
+
+    - name: Display Open WebUI logs for debugging
+      shell: docker logs --tail 50 open-webui
+      register: webui_logs
+      changed_when: false
+
+    - name: Show Open WebUI status
+      debug:
+        msg: "Open WebUI is {{ 'ready' if webui_ready.rc == 0 else 'still starting' }}"
 
     # ============================================================
     # Nginx Configuration for SRAM Authentication


### PR DESCRIPTION
Commented out gpt-oss:20b model, added option to reset Open WebUI database, and updated environment variables to improve user permissions and admin access. Deployment steps now include stopping containers, removing the database volume if requested, and forcing service recreation. Added tasks to wait for Open WebUI readiness and display logs for debugging.